### PR TITLE
Improve build script

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,17 +19,6 @@ repositories {
 	}
 }
 
-// overwrite jastadd2 dependency set by jastaddgradle
-configurations {
-	all {
-		resolutionStrategy.eachDependency { DependencyResolveDetails details ->
-			if (details.requested.name == 'jastadd2') {
-				details.useVersion '2.1.13'
-			}
-		}
-	}
-}
-
 dependencies {
 	// TODO(joqvist): Use only the needed transient dependencies from Shipshape,
 	// or even better wait for Shipshape to publish on Maven.
@@ -49,13 +38,14 @@ jastadd {
 	parser.name = 'JavaParser'
 }
 
-generateJava << {
-	ant.copy file: file('third_party/extendj/git/java8/src/org/extendj/scanner/JavaScanner.java'),
-		todir: file('src/gen/java/org/extendj/scanner'),
-		overwrite: true
-	ant.replace file: file('src/gen/java/org/extendj/scanner/JavaScanner.java'),
-		token: 'org.extendj',
-		value: 'com.google.simplecfg'
+generateJava.dependsOn 'copyScannerSource'
+
+// Copy the scanner decorator from ExtendJ into src/gen.
+task copyScannerSource(type: Copy) {
+	from 'third_party/extendj/git/java8/src/org/extendj/scanner'
+	into 'src/gen/java/com/google/simplecfg/scanner'
+	include 'JavaScanner.java'
+	filter { line -> line.replaceAll('org.extendj', 'com.google.simplecfg') }
 }
 
 test {


### PR DESCRIPTION
Replaced use of Ant tasks with native Gradle libraries.

Fixed generation of JavaScanner.java so that it generates into
src/gen/com/google/simplecfg/scanner/ instead of src/gen/org/extendj/scanner/,
matching the package declaration.

Removed overriding of JastAdd version used by the JastAddGradle plugin - the build plugin already uses 2.1.13.

fixes #4