### PR TITLE
Improve null guard check for conditional expr

### DIFF
--- a/src/main/jastadd/NullableDereferenceAnalysis.jrag
+++ b/src/main/jastadd/NullableDereferenceAnalysis.jrag
@@ -155,8 +155,9 @@ aspect NullableDereferenceAnalysis {
 
   /**
    * A CFG visitor that searches in the forward CFG for a nullable dereference.
-   * <p>
-   * The search stops at parts of the search tree guarded by a null check on the receiver variable.
+   *
+   * <p>The search stops at parts of the search tree guarded by a null check
+   * on the receiver variable.
    */
   class NullDereferenceLocator implements CfgVisitor {
     private final Variable var;
@@ -277,9 +278,9 @@ aspect NullableDereferenceAnalysis {
   eq WhileStmt.getStmt().hasNullGuard(Variable var) = getCondition().isNonNullWhenTrue(var);
   eq ForStmt.getStmt().hasNullGuard(Variable var) = getCondition().isNonNullWhenTrue(var);
   eq ConditionalExpr.getTrueExpr().hasNullGuard(Variable var) =
-      getCondition().isNonNullWhenTrue(var);
+      getCondition().isNonNullWhenTrue(var) || hasNullGuard(var);
   eq ConditionalExpr.getFalseExpr().hasNullGuard(Variable var) =
-      getCondition().isNonNullWhenFalse(var);
+      getCondition().isNonNullWhenFalse(var) || hasNullGuard(var);
   eq AndLogicalExpr.getRightOperand().hasNullGuard(Variable var) =
       getLeftOperand().isNonNullWhenTrue(var) || hasNullGuard(var);
   eq AndBitwiseExpr.getRightOperand().hasNullGuard(Variable var) =

--- a/src/test/java/com/google/simplecfg/NullableDereferenceTest.java
+++ b/src/test/java/com/google/simplecfg/NullableDereferenceTest.java
@@ -100,4 +100,10 @@ public class NullableDereferenceTest {
         "testdata/NullableDereference01.javax:31:12: Dereferencing p, which was declared @Nullable."
         );
   }
+
+  @Test public void issue11() {
+    Collection<String> findings = StmtCfgTest.findings("NullableDereferenceIssue11");
+    assertThat(findings).isEmpty();
+  }
+
 }

--- a/testdata/NullableDereferenceIssue11.javax
+++ b/testdata/NullableDereferenceIssue11.javax
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import javax.annotation.Nullable;
+
+/**
+ * This is test data, not real source code!
+ * Test for GitHub issue #11 (https://github.com/google/simplecfg/issues/11).
+ */
+public class Issue11 {
+  /** Test nullable deref in true-part of conditional expression. */
+  int test(@Nullable String p, boolean maybe) {
+    if (p == null || (maybe ? p.size() != 1 : false)) { // Negative finding.
+      return 1;
+    }
+    return 2;
+  }
+
+  /** Test nullable deref in false-part of conditional expression. */
+  int test2(@Nullable String p, boolean maybe) {
+    if (p == null || (maybe ? false : p.size() != 1)) { // Negative finding.
+      return 1;
+    }
+    return 2;
+  }
+
+  /** Test that the same null-guard used above works outside of conditional expression. */
+  int test3(@Nullable String p) {
+    if (p == null || p.size() != 1) { // Negative finding.
+      return 1;
+    }
+    return 2;
+  }
+}


### PR DESCRIPTION
Adds test for issue #11 in the GitHub issue tracker and fixes the issue.

The issue was fixed by adding a check for hasNullGuard to the conditional expression equations for the hasNullGuard attribute.

fixes #11