### PR TITLE
Improve null guard checks for equality expressions

### DIFF
--- a/src/main/jastadd/NullableDereferenceAnalysis.jrag
+++ b/src/main/jastadd/NullableDereferenceAnalysis.jrag
@@ -290,9 +290,19 @@ aspect NullableDereferenceAnalysis {
   /** @return {@code true} if the variable var is null when this expression is true. */
   syn boolean Expr.isNullWhenTrue(Variable var) = false;
 
+  eq NEExpr.isNullWhenTrue(Variable var) =
+      getLeftOperand().isTrue() && getRightOperand().isNullWhenFalse(var)
+      || getRightOperand().isTrue() && getLeftOperand().isNullWhenFalse(var)
+      || getLeftOperand().isFalse() && getRightOperand().isNullWhenTrue(var)
+      || getRightOperand().isFalse() && getLeftOperand().isNullWhenTrue(var);
+
   eq EQExpr.isNullWhenTrue(Variable var) =
       getLeftOperand().isNull() && getRightOperand().varDecl() == var
-      || getRightOperand().isNull() && getLeftOperand().varDecl() == var;
+      || getRightOperand().isNull() && getLeftOperand().varDecl() == var
+      || getLeftOperand().isTrue() && getRightOperand().isNullWhenTrue(var)
+      || getRightOperand().isTrue() && getLeftOperand().isNullWhenTrue(var)
+      || getLeftOperand().isFalse() && getRightOperand().isNullWhenFalse(var)
+      || getRightOperand().isFalse() && getLeftOperand().isNullWhenFalse(var);
 
   eq LogNotExpr.isNullWhenTrue(Variable var) = getOperand().isNullWhenFalse(var);
 
@@ -332,7 +342,17 @@ aspect NullableDereferenceAnalysis {
 
   eq NEExpr.isNullWhenFalse(Variable var) =
       getLeftOperand().isNull() && getRightOperand().varDecl() == var
-      || getRightOperand().isNull() && getLeftOperand().varDecl() == var;
+      || getRightOperand().isNull() && getLeftOperand().varDecl() == var
+      || getLeftOperand().isTrue() && getRightOperand().isNullWhenTrue(var)
+      || getRightOperand().isTrue() && getLeftOperand().isNullWhenTrue(var)
+      || getLeftOperand().isFalse() && getRightOperand().isNullWhenFalse(var)
+      || getRightOperand().isFalse() && getLeftOperand().isNullWhenFalse(var);
+
+  eq EQExpr.isNullWhenFalse(Variable var) =
+      getLeftOperand().isTrue() && getRightOperand().isNullWhenFalse(var)
+      || getRightOperand().isTrue() && getLeftOperand().isNullWhenFalse(var)
+      || getLeftOperand().isFalse() && getRightOperand().isNullWhenTrue(var)
+      || getRightOperand().isFalse() && getLeftOperand().isNullWhenTrue(var);
 
   eq LogNotExpr.isNullWhenFalse(Variable var) = getOperand().isNullWhenTrue(var);
 
@@ -374,7 +394,17 @@ aspect NullableDereferenceAnalysis {
 
   eq NEExpr.isNonNullWhenTrue(Variable var) =
       getLeftOperand().isNull() && getRightOperand().varDecl() == var
-      || getRightOperand().isNull() && getLeftOperand().varDecl() == var;
+      || getRightOperand().isNull() && getLeftOperand().varDecl() == var
+      || getLeftOperand().isTrue() && getRightOperand().isNonNullWhenFalse(var)
+      || getRightOperand().isTrue() && getLeftOperand().isNonNullWhenFalse(var)
+      || getLeftOperand().isFalse() && getRightOperand().isNonNullWhenTrue(var)
+      || getRightOperand().isFalse() && getLeftOperand().isNonNullWhenTrue(var);
+
+  eq EQExpr.isNonNullWhenTrue(Variable var) =
+      getLeftOperand().isTrue() && getRightOperand().isNonNullWhenTrue(var)
+      || getRightOperand().isTrue() && getLeftOperand().isNonNullWhenTrue(var)
+      || getLeftOperand().isFalse() && getRightOperand().isNonNullWhenFalse(var)
+      || getRightOperand().isFalse() && getLeftOperand().isNonNullWhenFalse(var);
 
   eq LogNotExpr.isNonNullWhenTrue(Variable var) = getOperand().isNullWhenTrue(var);
 
@@ -416,9 +446,19 @@ aspect NullableDereferenceAnalysis {
   /** @return {@code true} if the variable var is non-null when this expression is false. */
   syn boolean Expr.isNonNullWhenFalse(Variable var) = false;
 
+  eq NEExpr.isNonNullWhenFalse(Variable var) =
+      getLeftOperand().isTrue() && getRightOperand().isNonNullWhenTrue(var)
+      || getRightOperand().isTrue() && getLeftOperand().isNonNullWhenTrue(var)
+      || getLeftOperand().isFalse() && getRightOperand().isNonNullWhenFalse(var)
+      || getRightOperand().isFalse() && getLeftOperand().isNonNullWhenFalse(var);
+
   eq EQExpr.isNonNullWhenFalse(Variable var) =
       getLeftOperand().isNull() && getRightOperand().varDecl() == var
-      || getRightOperand().isNull() && getLeftOperand().varDecl() == var;
+      || getRightOperand().isNull() && getLeftOperand().varDecl() == var
+      || getLeftOperand().isTrue() && getRightOperand().isNonNullWhenFalse(var)
+      || getRightOperand().isTrue() && getLeftOperand().isNonNullWhenFalse(var)
+      || getLeftOperand().isFalse() && getRightOperand().isNonNullWhenTrue(var)
+      || getRightOperand().isFalse() && getLeftOperand().isNonNullWhenTrue(var);
 
   eq LogNotExpr.isNonNullWhenFalse(Variable var) = getOperand().isNonNullWhenTrue(var);
 

--- a/src/test/java/com/google/simplecfg/NullableDereferenceTest.java
+++ b/src/test/java/com/google/simplecfg/NullableDereferenceTest.java
@@ -100,4 +100,19 @@ public class NullableDereferenceTest {
         "testdata/NullableDereference01.javax:31:12: Dereferencing p, which was declared @Nullable."
         );
   }
+
+  @Test public void issue12() {
+    Collection<String> findings = StmtCfgTest.findings("NullableDereferenceIssue12");
+    assertThat(findings).isEmpty();
+  }
+
+  @Test public void eqExpr() {
+    Collection<String> findings = StmtCfgTest.findings("NullableDereferenceEqExpr");
+    assertThat(findings).isEmpty();
+  }
+
+  @Test public void neExpr() {
+    Collection<String> findings = StmtCfgTest.findings("NullableDereferenceNeExpr");
+    assertThat(findings).isEmpty();
+  }
 }

--- a/testdata/NullableDereferenceEqExpr.javax
+++ b/testdata/NullableDereferenceEqExpr.javax
@@ -1,0 +1,200 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import javax.annotation.Nullable;
+
+/**
+ * This is test data, not real source code!
+ * This contains tests for EQExpr null guards. Each test method contains
+ * one false positive dereference of the parameter p. The parameter is
+ * guarded by a null check in an equality expression.
+ */
+public class NullableDereferenceEqExpr {
+  /**
+   * Non-null when true condition.
+   * Null test in left hand side, comparing to false.
+   */
+  int nntLhsFalse(@Nullable String p) {
+    if (false == (p == null)) {
+      return p.size();
+    }
+    return 0;
+  }
+
+  /**
+   * Non-null when true condition.
+   * Null test in right hand side, comparing to false.
+   */
+  int nntRhsFalse(@Nullable String p) {
+    if ((p == null) == false) {
+      return p.size();
+    }
+    return 0;
+  }
+
+  /**
+   * Non-null when true condition.
+   * Null test in left hand side, comparing to true.
+   */
+  int nntLhsTrue(@Nullable String p) {
+    if (true == (p != null)) {
+      return p.size();
+    }
+    return 0;
+  }
+
+  /**
+   * Non-null when true condition.
+   * Null test in right hand side, comparing to true.
+   */
+  int nntRhsTrue(@Nullable String p) {
+    if ((p != null) == true) {
+      return p.size();
+    }
+    return 0;
+  }
+
+  /**
+   * Non-null when false condition.
+   * Null test in left hand side, comparing to false.
+   */
+  int nnfLhsFalse(@Nullable String p) {
+    if (false == (p != null)) {
+      return 0;
+    }
+    return p.size();
+  }
+
+  /**
+   * Non-null when false condition.
+   * Null test in right hand side, comparing to false.
+   */
+  int nnfRhsFalse(@Nullable String p) {
+    if ((p != null) == false) {
+      return 0;
+    }
+    return p.size();
+  }
+
+  /**
+   * Non-null when false condition.
+   * Null test in left hand side, comparing to true.
+   */
+  int nnfLhsTrue(@Nullable String p) {
+    if (true == (p == null)) {
+      return 0;
+    }
+    return p.size();
+  }
+
+  /**
+   * Non-null when false condition.
+   * Null test in right hand side, comparing to true.
+   */
+  int nnfRhsTrue(@Nullable String p) {
+    if ((p == null) == true) {
+      return 0;
+    }
+    return p.size();
+  }
+
+  /**
+   * Null when true condition (negated).
+   * Null test in left hand side, comparing to false.
+   */
+  int ntLhsFalse(@Nullable String p) {
+    if (!(false == (p != null))) {
+      return p.size();
+    }
+    return 0;
+  }
+
+  /**
+   * Null when true condition (negated).
+   * Null test in right hand side, comparing to false.
+   */
+  int ntRhsFalse(@Nullable String p) {
+    if (!((p != null) == false)) {
+      return p.size();
+    }
+    return 0;
+  }
+
+  /**
+   * Null when true condition (negated).
+   * Null test in left hand side, comparing to true.
+   */
+  int ntLhsTrue(@Nullable String p) {
+    if (!(true == (p == null))) {
+      return p.size();
+    }
+    return 0;
+  }
+
+  /**
+   * Null when true condition (negated).
+   * Null test in right hand side, comparing to true.
+   */
+  int ntRhsTrue(@Nullable String p) {
+    if (!((p == null) == true)) {
+      return p.size();
+    }
+    return 0;
+  }
+
+  /**
+   * Null when false condition (negated).
+   * Null test in left hand side, comparing to false.
+   */
+  int nfLhsFalse(@Nullable String p) {
+    if (!(false == (p == null))) {
+      return 0;
+    }
+    return p.size();
+  }
+
+  /**
+   * Null when false condition (negated).
+   * Null test in right hand side, comparing to false.
+   */
+  int nfRhsFalse(@Nullable String p) {
+    if (!((p == null) == false)) {
+      return 0;
+    }
+    return p.size();
+  }
+
+  /**
+   * Null when false condition (negated).
+   * Null test in left hand side, comparing to true.
+   */
+  int nfLhsTrue(@Nullable String p) {
+    if (!(true == (p != null))) {
+      return 0;
+    }
+    return p.size();
+  }
+
+  /**
+   * Null when false condition (negated).
+   * Null test in right hand side, comparing to true.
+   */
+  int nfRhsTrue(@Nullable String p) {
+    if (!((p != null) == true)) {
+      return 0;
+    }
+    return p.size();
+  }
+}

--- a/testdata/NullableDereferenceIssue12.javax
+++ b/testdata/NullableDereferenceIssue12.javax
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import javax.annotation.Nullable;
+
+/**
+ * This is test data, not real source code!
+ * Test for GitHub issue #12 (https://github.com/google/simplecfg/issues/12).
+ */
+public class NullableDereferenceIssue12 {
+  /**
+   * The condition (false == x) is equivalent to (!x), however this test
+   * shows a bug causing a null guard check to fail for (false == x)
+   * expressions.
+   */
+  int test(@Nullable String p) {
+    if (false == (p != null)) {
+      return 0;
+    }
+    return p.size(); // Negative finding: not reachable if p == null.
+  }
+
+  /**
+   * The condition in this if-statement and the one in the first test are
+   * equivalent but this version does not give a false positive.
+   */
+  int test2(@Nullable String p) {
+    if (!(p != null)) {
+      return 0;
+    }
+    return p.size(); // Negative finding.
+  }
+}

--- a/testdata/NullableDereferenceNeExpr.javax
+++ b/testdata/NullableDereferenceNeExpr.javax
@@ -1,0 +1,200 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import javax.annotation.Nullable;
+
+/**
+ * This is test data, not real source code!
+ * This contains tests for NEExpr null guards. Each test method contains
+ * one false positive dereference of the parameter p. The parameter is
+ * guarded by a null check in an inequality expression.
+ */
+public class NullableDereferenceNeExpr {
+  /**
+   * Non-null when true condition.
+   * Null test in left hand side, comparing to false.
+   */
+  int nntLhsFalse(@Nullable String p) {
+    if (false != (p != null)) {
+      return p.size();
+    }
+    return 0;
+  }
+
+  /**
+   * Non-null when true condition.
+   * Null test in right hand side, comparing to false.
+   */
+  int nntRhsFalse(@Nullable String p) {
+    if ((p != null) != false) {
+      return p.size();
+    }
+    return 0;
+  }
+
+  /**
+   * Non-null when true condition.
+   * Null test in left hand side, comparing to true.
+   */
+  int nntLhsTrue(@Nullable String p) {
+    if (true != (p == null)) {
+      return p.size();
+    }
+    return 0;
+  }
+
+  /**
+   * Non-null when true condition.
+   * Null test in right hand side, comparing to true.
+   */
+  int nntRhsTrue(@Nullable String p) {
+    if ((p == null) != true) {
+      return p.size();
+    }
+    return 0;
+  }
+
+  /**
+   * Non-null when false condition.
+   * Null test in left hand side, comparing to false.
+   */
+  int nnfLhsFalse(@Nullable String p) {
+    if (false != (p == null)) {
+      return 0;
+    }
+    return p.size();
+  }
+
+  /**
+   * Non-null when false condition.
+   * Null test in right hand side, comparing to false.
+   */
+  int nnfRhsFalse(@Nullable String p) {
+    if ((p == null) != false) {
+      return 0;
+    }
+    return p.size();
+  }
+
+  /**
+   * Non-null when false condition.
+   * Null test in left hand side, comparing to true.
+   */
+  int nnfLhsTrue(@Nullable String p) {
+    if (true != (p != null)) {
+      return 0;
+    }
+    return p.size();
+  }
+
+  /**
+   * Non-null when false condition.
+   * Null test in right hand side, comparing to true.
+   */
+  int nnfRhsTrue(@Nullable String p) {
+    if ((p != null) != true) {
+      return 0;
+    }
+    return p.size();
+  }
+
+  /**
+   * Null when true condition (negated).
+   * Null test in left hand side, comparing to false.
+   */
+  int ntLhsFalse(@Nullable String p) {
+    if (!(false != (p == null))) {
+      return p.size();
+    }
+    return 0;
+  }
+
+  /**
+   * Null when true condition (negated).
+   * Null test in right hand side, comparing to false.
+   */
+  int ntRhsFalse(@Nullable String p) {
+    if (!((p == null) != false)) {
+      return p.size();
+    }
+    return 0;
+  }
+
+  /**
+   * Null when true condition (negated).
+   * Null test in left hand side, comparing to true.
+   */
+  int ntLhsTrue(@Nullable String p) {
+    if (!(true != (p != null))) {
+      return p.size();
+    }
+    return 0;
+  }
+
+  /**
+   * Null when true condition (negated).
+   * Null test in right hand side, comparing to true.
+   */
+  int ntRhsTrue(@Nullable String p) {
+    if (!((p != null) != true)) {
+      return p.size();
+    }
+    return 0;
+  }
+
+  /**
+   * Null when false condition (negated).
+   * Null test in left hand side, comparing to false.
+   */
+  int nfLhsFalse(@Nullable String p) {
+    if (!(false != (p != null))) {
+      return 0;
+    }
+    return p.size();
+  }
+
+  /**
+   * Null when false condition (negated).
+   * Null test in right hand side, comparing to false.
+   */
+  int nfRhsFalse(@Nullable String p) {
+    if (!((p != null) != false)) {
+      return 0;
+    }
+    return p.size();
+  }
+
+  /**
+   * Null when false condition (negated).
+   * Null test in left hand side, comparing to true.
+   */
+  int nfLhsTrue(@Nullable String p) {
+    if (!(true != (p == null))) {
+      return 0;
+    }
+    return p.size();
+  }
+
+  /**
+   * Null when false condition (negated).
+   * Null test in right hand side, comparing to true.
+   */
+  int nfRhsTrue(@Nullable String p) {
+    if (!((p == null) != true)) {
+      return 0;
+    }
+    return p.size();
+  }
+}


### PR DESCRIPTION
Fixed issue 12 for the NullableDereference analyser. Improved null test checking for equality expressions and added tests to cover all combinations of null-when-true/false and non-null-when-true/false and all combinations of true/false constant expressions in left hand side or right hand side.

Also added a test that matches the test case in issue 12.