### PR TITLE
Assume all method calls are null guard equivalent

### DIFF
--- a/src/main/jastadd/NullableDereferenceAnalysis.jrag
+++ b/src/main/jastadd/NullableDereferenceAnalysis.jrag
@@ -25,16 +25,10 @@
  * p.x(); // Guarded by null check above.
  * }
  *
- * <p>The analysis also assumes that a method call to {@code checkNotNull}, or {@code isNotNull}
- * will also work as a null guard. There are more possible variations of methods guarding against
- * nullness that could be considered, but currently we only check for these methods:
- *
- * <ul>
- * <li>{@code checkNotNull}, {@code checkNonNull}: assume that any control flow path following this
- * call with the analyzed parameter as the first argument are safe for dereferencing that parameter
- * <li>{@code isNotNull}, {@code isNonNull}: assume that calls to methods with names that start with
- * these prefixes guard the single argument against nullness
- * </ul>
+ * <p>The analysis is not intraprocedural, so in order to avoid false positives
+ * where a method call guards against nullness the analyzer assumes that
+ * calling a method with an argument x results in an exception if x is null and
+ * thus works like an effective null guard for x.
  *
  * <p>To find potential null dereferences on nullable parameters, the analysis does a forward CFG
  * traversal from the entry-point of the method. Note that this is only done whenever a
@@ -226,16 +220,22 @@ aspect NullableDereferenceAnalysis {
   syn boolean CfgNode.isNullGuard(Variable var, CfgNode succ) = false;
 
   /**
-   * We assume that calling a method named checkNotNull on the variable var will throw an exception
-   * if the argument is null.
+   * We assume that calling a method with the variable var as an argument
+   * results in an exception thrown by the method call if var is null. This is
+   * not true for many methods, but it should reduce the false positive rate
+   * for the NullableDereference analyzer.
    */
   eq CfgMethodCall.isNullGuard(Variable var, CfgNode succ) {
     if (succ instanceof CfgException) {
       return false;
     }
     MethodAccess access = methodAccess();
-    return (access.name().equals("checkNotNull") || access.name().equals("checkNonNull"))
-        && access.getNumArg() >= 1 && access.getArg(0).isVariable(var);
+    for (Expr arg : access.getArgList()) {
+      if (arg.isVariable(var)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /** Check if this branch has a null-guarding condition.  */

--- a/src/test/java/com/google/simplecfg/NullableDereferenceTest.java
+++ b/src/test/java/com/google/simplecfg/NullableDereferenceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Google Inc. All Rights Reserved.
+ * Copyright 2016 Google Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -127,5 +127,12 @@ public class NullableDereferenceTest {
   @Test public void neExpr() {
     Collection<String> findings = StmtCfgTest.findings("NullableDereferenceNeExpr");
     assertThat(findings).isEmpty();
+  }
+
+  @Test public void methodCall() {
+    Collection<String> findings = StmtCfgTest.findings("NullableDereferenceMethodCall");
+    assertThat(findings).containsExactly(
+        "testdata/NullableDereferenceMethodCall.javax:41:16: Dereferencing p, which was declared @Nullable."
+        );
   }
 }

--- a/testdata/NullableDereferenceMethodCall.javax
+++ b/testdata/NullableDereferenceMethodCall.javax
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import javax.annotation.Nullable;
+
+/**
+ * This is test data, not real source code!
+ *
+ * <p>This class contains tests checking that a null dereference
+ * finding is not reported for a parameter p after p has been used
+ * as an argument in a method call. The NullableDereference
+ * analyzer is not an interprocedural analysis, so we can not know
+ * if the method called will perform a null check and ensure
+ * non-nullness of the argument after the call completes. Instead
+ * we should just stop analyzing a parameter after it has been
+ * passed to another method.
+ */
+public class NullableDereferenceMethodCall {
+  public interface SomeApi {
+    public void doSomething(String str);
+  }
+
+  int interfaceMethodCall(@Nullable String p, SomeApi s) {
+    s.doSomething(p);
+    return p.size(); // No finding here, since doSomething might have done a null check.
+  }
+
+  int interfaceMethodCall2(@Nullable String p, SomeApi s) {
+    int size = p.size(); // Finding here: no call yet.
+    s.doSomething(p);
+    return size;
+  }
+
+  int methodCall(@Nullable String p, String q) {
+    q.equals(p);
+    return p.size();
+  }
+
+  int localMethodCall(@Nullable String p) {
+    localMethod(p);
+    return p.size(); // No finding here, we don't analyze even local methods.
+  }
+}


### PR DESCRIPTION
The NullableDereference analyzer now considers a method call with an argument x
as being a null guard on argument x.  This removes some false positives caused
by calling precondition-like methods that throw an exception if an argument is
null. Such methods could be used as effective null guards, aborting the current
control flow if some parameter is null.

This change reduces the precision of the NullableDereference analyzer, but
hopefully the reduced false positive rate outweighs that drawback.